### PR TITLE
- fixes missing version to publish task

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Extract release notes
         id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
+        uses: ffurrer2/extract-release-notes@v1.8.11
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
sorry @samwelkanda I didn't know they didn't have a tag just for v1 (rolling)
https://github.com/microsoftgraph/msgraph-beta-sdk-python/actions/runs/7641221920/job/20818085449