### PR TITLE
Bump kiota abstr to >=1.3.0 due to multipart support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 description = "The Microsoft Graph Beta Python SDK"
 dependencies = [
     "azure-identity >=1.12.0",
-    "microsoft-kiota-abstractions >=1.0.0,<2.0.0",
+    "microsoft-kiota-abstractions >=1.3.0,<2.0.0",
     "microsoft-kiota-authentication-azure >=1.0.0,<2.0.0",
     "microsoft-kiota-serialization-json >=1.0.0,<2.0.0",
     "microsoft-kiota-serialization-text >=1.0.0,<2.0.0",


### PR DESCRIPTION
Applying the same change that was made in the non-beta repository (https://github.com/microsoftgraph/msgraph-sdk-python/pull/817) here, as requested (https://github.com/microsoftgraph/msgraph-sdk-python/pull/817#pullrequestreview-2182690419).