### PR TITLE
chore: downgrade build tools so that we emit 2.3 metadata

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,10 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - "msgraph_beta/**"
   schedule:
     - cron: '1 * * * 1'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "msgraph-beta-sdk"
+
+# Pin metadata to 2.3 until ESRP Release supports License-Expression over the 
+# deprecated License field. Update License to License-Expression when unpinning 
+# metadata version.
+metadata-version = 2.3
+
 # The SDK version
 # x-release-please-start-version
 version = "1.59.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+# When ESRP Release supports License-Expression, update flit_core to use >=3.2,<4
+requires = ["flit_core==3.10"]
 build-backend = "flit_core.buildapi"
 
 [project]
 name = "msgraph-beta-sdk"
-
-# Pin metadata to 2.3 until ESRP Release supports License-Expression over the 
-# deprecated License field. Update License to License-Expression when unpinning 
-# metadata version.
-metadata-version = 2.3
-
 # The SDK version
 # x-release-please-start-version
 version = "1.59.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,8 +16,8 @@ cryptography==48.0.0
 Deprecated==1.3.1
 dill==0.4.1
 docutils==0.23
-flit==3.12.0
-flit_core==3.12.0
+flit==3.10.0
+flit_core==3.10.0
 frozenlist==1.8.0
 h11==0.16.0
 h2==4.3.0


### PR DESCRIPTION
* update CodeQL to only run when there are changes to files on PRs
* down grade build tools so that it emits metadata version 2.3 -- this is so we can get a release out due to ESRP Release bug.