### PR TITLE
fix(deps): bump msgraph-core floor to >=1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "microsoft-kiota-serialization-text >=1.9.0,<2.0.0",
     "microsoft-kiota-serialization-form >=1.9.0",
     "microsoft-kiota-serialization-multipart >=1.9.0",
-    "msgraph_core >=1.3.1"
+    "msgraph_core >=1.5.1"
 
 ]
 requires-python = ">=3.10"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,7 +41,7 @@ microsoft-kiota-serialization-multipart==1.11.6
 microsoft-kiota-serialization-text==1.11.6
 msal==1.37.0
 msal-extensions==1.3.1
-msgraph-core==1.4.0
+msgraph-core==1.5.1
 multidict==6.7.1
 mypy==2.2.0
 mypy-extensions==1.1.0


### PR DESCRIPTION
Raises the runtime `msgraph-core` lower bound from `>=1.3.1` to `>=1.5.1`, and updates the dev lockfile to match.

**Changes:**
- `pyproject.toml`: runtime dep `msgraph_core >=1.3.1` -> `>=1.5.1`
- `requirements-dev.txt`: `msgraph-core==1.4.0` -> `==1.5.1` (the `microsoft-kiota-*` dev pins are already at `1.11.6`, which satisfies core 1.5.1)

